### PR TITLE
[#6] [TASK] post/toast 컴포넌트 제작

### DIFF
--- a/src/app/dev/junyeol/page.tsx
+++ b/src/app/dev/junyeol/page.tsx
@@ -6,6 +6,8 @@ import { ConfirmModal } from "@/components/modal/ConfirmModal";
 import { ActionModal } from "@/components/modal/ActionModal";
 import { useModal } from "@/hooks/UseModal";
 import { PostCard } from "@/components/post/postCard";
+import Button from "@/components/common/Button";
+import { useToast } from "@/components/toast/toastProvider";
 
 export default function JunyeolPage() {
   const searchParams = useSearchParams();
@@ -16,10 +18,14 @@ export default function JunyeolPage() {
 
   const confirmModal = useModal();
   const actionModal = useModal();
+  const { showToast } = useToast();
 
   const handleReject = () => {
     // 실제 거절 API 호출 등
-    console.log("거절 확정");
+    showToast("거절했어요.",
+      {
+        variant: "error",
+      });
   };
 
   const MOCK_POST = {
@@ -42,19 +48,26 @@ export default function JunyeolPage() {
       />
 
       <div className="flex flex-col items-center justify-center gap-4 p-8">
-        <button
-          className="w-80 border px-4 py-2"
+        <Button
+          size="medium"
           onClick={confirmModal.open}
         >
           Confirm 모달
-        </button>
+        </Button>
 
-        <button
-          className="w-80 border px-4 py-2"
+        <Button
+          size="medium"
           onClick={actionModal.open}
         >
           Action 모달
-        </button>
+        </Button>
+
+        <Button
+          size="medium"
+          onClick={handleReject}
+        >
+          Toast 메시지
+        </Button>
       </div>
 
       <ConfirmModal

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { UserRole } from '@/components/common/NavBar';
 import './globals.css';
 import { spoqa } from './fonts';
 import Footer from '@/components/common/Footer';
+import { ToastProvider } from "@/components/toast/toastProvider";
 
 export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
   const isLoggedIn = false; // 임시
@@ -12,11 +13,13 @@ export default function RootLayout({ children }: Readonly<{ children: ReactNode 
   return (
     <html lang="ko" className={spoqa.className}>
       <body className="min-h-screen flex flex-col">
-        <NavBar isLoggedIn={isLoggedIn} role={role} />
-        <main className="flex-1">
-          <div>{children}</div>
-        </main>
-        <Footer />
+        <ToastProvider>
+          <NavBar isLoggedIn={isLoggedIn} role={role} />
+          <main className="flex-1">
+            <div>{children}</div>
+          </main>
+          <Footer />
+        </ToastProvider>
       </body>
     </html>
   );

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -32,16 +32,13 @@ export function Toast({ isOpen, message, variant = "info" }: ToastProps) {
 
   /**
    * variant에 따라 배경/텍스트 색상 분기
-   * - error   : red-30/white
-   * - success : green-20/white
-   * - info    : gray-30/black
    */
-  const variantClass =
-    variant === "error"
-      ? "bg-red-30 text-white"
-      : variant === "success"
-      ? "bg-green-20 text-white"
-      : "bg-gray-30 text-black";
+  const variantClasses: Record<ToastVariant, string> = {
+    error: "bg-red-30 text-white",
+    success: "bg-green-20 text-white",
+    info: "bg-gray-30 text-black",
+  };
+  const variantClass = variantClasses[variant];
 
   /**
    * createPortal
@@ -52,6 +49,7 @@ export function Toast({ isOpen, message, variant = "info" }: ToastProps) {
     // 전체 화면을 덮는 래퍼 (클릭 막기 위해 pointer-events-none)
     <div className="fixed inset-x-0 bottom-12 z-9999 flex justify-center pointer-events-none">
       <div
+        role="status"
         className={[
           // pointer-events-auto로 클릭 가능하게 설정(배경 클릭 막기 위해)
           "pointer-events-auto",

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * 토스트 스타일 종류
+ * - "error"  : 거절 / 실패 등
+ * - "success": 성공
+ * - "info"   : 일반 안내
+ */
+export type ToastVariant = "success" | "error" | "info";
+
+/**
+ * Toast 컴포넌트 Props
+ */
+type ToastProps = {
+  isOpen: boolean;        // 토스트 노출 여부
+  message: ReactNode;     // 토스트에 표시할 내용 (문자열 또는 ReactNode)
+  variant?: ToastVariant; // 색상, 스타일 종류
+};
+
+/**
+ * Toast UI 컴포넌트
+ */
+export function Toast({ isOpen, message, variant = "info" }: ToastProps) {
+  // 서버 사이드 렌더링 시에는 아무 것도 렌더링 하지 않음
+  if (typeof window === "undefined") return null;
+
+  // 열려 있지 않으면 아무 것도 렌더링하지 않음
+  if (!isOpen) return null;
+
+  /**
+   * variant에 따라 배경/텍스트 색상 분기
+   * - error   : red-30/white
+   * - success : green-20/white
+   * - info    : gray-30/black
+   */
+  const variantClass =
+    variant === "error"
+      ? "bg-red-30 text-white"
+      : variant === "success"
+      ? "bg-green-20 text-white"
+      : "bg-gray-30 text-black";
+
+  /**
+   * createPortal
+   * - 현재 컴포넌트 트리와 상관없이 document.body 바로 아래에 렌더링
+   * - z-index / position 충돌 없이 전역 오버레이처럼 사용 가능
+   */
+  return createPortal(
+    // 전체 화면을 덮는 래퍼 (클릭 막기 위해 pointer-events-none)
+    <div className="fixed inset-x-0 bottom-12 z-9999 flex justify-center pointer-events-none">
+      <div
+        className={[
+          // pointer-events-auto로 클릭 가능하게 설정(배경 클릭 막기 위해)
+          "pointer-events-auto",
+          "flex items-center justify-center rounded-[5px] tj-body1 px-4 py-2.5",
+          variantClass,
+        ].join(" ")}
+      >
+        {message}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -50,12 +50,9 @@ export function Toast({ isOpen, message, variant = "info" }: ToastProps) {
     <div className="fixed inset-x-0 bottom-12 z-9999 flex justify-center pointer-events-none">
       <div
         role="status"
-        className={[
+        className={
           // pointer-events-auto로 클릭 가능하게 설정(배경 클릭 막기 위해)
-          "pointer-events-auto",
-          "flex items-center justify-center rounded-[5px] tj-body1 px-4 py-2.5",
-          variantClass,
-        ].join(" ")}
+          `pointer-events-auto flex items-center justify-center rounded-[5px] tj-body1 px-4 py-2.5 ${variantClass}`}
       >
         {message}
       </div>

--- a/src/components/toast/toastProvider.tsx
+++ b/src/components/toast/toastProvider.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useEffect,
   ReactNode,
 } from "react";
 import { Toast, ToastVariant } from "./toast";
@@ -83,6 +84,15 @@ export function ToastProvider({ children }: ToastProviderProps) {
     },
     []
   );
+
+  // Provider 언마운트 시 타이머 정리
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current);
+      }
+    };
+  }, []);
 
   // Context에 내려줄 값 메모이제이션
   const value = useMemo(

--- a/src/components/toast/toastProvider.tsx
+++ b/src/components/toast/toastProvider.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  ReactNode,
+} from "react";
+import { Toast, ToastVariant } from "./toast";
+
+/**
+ * ToastContext에 저장될 값 타입
+ */
+type ToastContextValue = {
+  // 토스트를 띄우는 함수
+  showToast: (
+    message: ReactNode,
+    options?: {
+      variant?: ToastVariant; // "error" | "success" | "info", 기본값 "info"
+      duration?: number;      // 자동으로 닫힐 때 까지의 시간(ms), 기본값 2000ms
+    }
+  ) => void;
+};
+
+/**
+ * 실제 Context 객체
+ * - 초기값은 null → useToast에서 null 체크
+ */
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+/**
+ * Provider 컴포넌트 Props
+ */
+type ToastProviderProps = {
+  children: ReactNode;
+};
+
+/**
+ * ToastProvider
+ * - 전역 토스트 상태를 관리하는 컴포넌트
+ * - layout.tsx에서 앱 전체를 <ToastProvider>로 감싸서 사용
+ */
+export function ToastProvider({ children }: ToastProviderProps) {
+  const [isOpen, setIsOpen] = useState(false);                  // 토스트 열림 상태
+  const [message, setMessage] = useState<ReactNode>("");        // 토스트에 표시할 메시지
+  const [variant, setVariant] = useState<ToastVariant>("info"); // 토스트 스타일 종류
+  const closeTimerRef = useRef<number | null>(null);            // 현재 열려 있는 토스트를 닫기 위한 타이머 ID 
+
+  /**
+   * showToast
+   * 
+   * - 어디서든 호출해서 토스트를 띄우는 함수
+   * - 여러 번 연속으로 호출될 때 이전 타이머는 정리해서
+   *   "가장 마지막으로 호출된 토스트" 기준으로 duration을 적용
+   * 사용 예:
+   *   showToast("거절 했어요.", { variant: "error", duration: 2000 });
+   */
+  const showToast: ToastContextValue["showToast"] = useCallback(
+    (msg, options) => {
+      // 메시지/스타일 업데이트
+      setMessage(msg);                        // 토스트 메시지 설정
+      setVariant(options?.variant ?? "info"); // 스타일 기본값 "info"
+      setIsOpen(true);                        // 토스트 열기
+
+      // 닫기 타이머 설정(duration 기본값 2000ms)
+      const duration = options?.duration ?? 2000;
+
+      // 이전에 설정된 타이머가 있으면 제거 (중복 close 방지)
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current);
+      }
+
+      // 새 타이머 설정
+      const timerId = window.setTimeout(() => {
+        setIsOpen(false);
+        closeTimerRef.current = null;
+      }, duration);
+
+      closeTimerRef.current = timerId;
+    },
+    []
+  );
+
+  // Context에 내려줄 값 메모이제이션
+  const value = useMemo(
+    () => ({
+      showToast,
+    }),
+    [showToast]
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {/* 실제 페이지 내용 */}
+      {children}
+
+      {/* 항상 트리 최하단에 붙어 있는 전역 토스트 */}
+      <Toast isOpen={isOpen} message={message} variant={variant} />
+    </ToastContext.Provider>
+  );
+}
+
+/**
+ * useToast
+ *
+ * - 컴포넌트에서 토스트를 사용하기 위한 커스텀 훅
+ * - 반드시 <ToastProvider>로 감싸진 영역 내부에서만 사용해야 함
+ */
+export function useToast() {
+  const ctx = useContext(ToastContext);
+
+  // Provider 바깥에서 사용하면 바로 에러를 표시해서 개발 단계에서 잡을 수 있도록 함
+  if (!ctx) {
+    throw new Error("useToast는 ToastProvider 안에서만 사용할 수 있습니다.");
+  }
+
+  return ctx;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
관련된 이슈가 있다면 링크로 연결해주세요. ex) `close #1`
close #6 

## ✨ 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI 변경
- [ ] 리팩토링
- [x] 문서 업데이트
- [x] 기타

## 📌 PR 요약 (선택)
특정 버튼 클릭시 화면 하단부분에 2초간 toast 메시지가 표시되도록 구현
toast UI 컴포넌트, toast 기능/훅 컴포넌트 제작
layout.tsx에서 body 안의 children 부분을 ToastProvider로 감싸서 토스트 메시지를 전역적으로 사용할 수 있게 수정하였습니다.


## 📸 스크린샷 (선택)
<img width="1920" height="935" alt="image" src="https://github.com/user-attachments/assets/aac46afe-eb06-4166-b762-7de31f0ed6e9" />

Closes #6
