### PR TITLE
[#66] [REFACTOR] post 컴포넌트 리팩토링

### DIFF
--- a/src/app/dev/junyeol/page.tsx
+++ b/src/app/dev/junyeol/page.tsx
@@ -86,27 +86,12 @@ export default function JunyeolPage() {
         <div className="mb-8 flex justify-center gap-6">
           <PostCard
             status="active"
-            size="large"
             {...MOCK_POST}
           />
           <PostCard
             status="inactive"
-            size="large"
             {...MOCK_POST}
             wageBadgeText="50%"
-          />
-        </div>
-
-        <div className="flex justify-center gap-6">
-          <PostCard
-            status="active"
-            size="small"
-            {...MOCK_POST}
-          />
-          <PostCard
-            status="inactive"
-            size="small"
-            {...MOCK_POST}
           />
         </div>
       </div>

--- a/src/components/post/postCard.tsx
+++ b/src/components/post/postCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { useMemo } from "react";
 import PostArrow from "./icon/PostArrow";
 import PostPath from "./icon/PostPath";
 import PostClock from "./icon/PostClock";
@@ -33,8 +34,10 @@ export function PostCard({
   const isInactive = status === "inactive";
 
   // 작은 카드(모바일에서 사용) 날짜/시간 분리
-  const [datePart, ...rest] = scheduleText.split(" ");
-  const timePart = rest.join(" ");
+  const [datePart, timePart] = useMemo(() => {
+    const [date, ...rest] = scheduleText.split(" ");
+    return [date, rest.join(" ")];
+  }, [scheduleText]);
 
   return (
     <article
@@ -154,7 +157,7 @@ export function PostCard({
                 </div>
               </div>
             </>
-          )}    
+          )}
         </div>
       </div>
     </article>

--- a/src/components/post/postCard.tsx
+++ b/src/components/post/postCard.tsx
@@ -72,8 +72,8 @@ export function PostCard({
         {/* 비활성(지난 공고) 오버레이 */}
         {isInactive && (
           <div className="absolute inset-0 flex items-center justify-center bg-black/70 text-gray-30">
-            <span className="flex md:hidden tj-h3">지난 공고</span>
-            <span className="hidden md:flex tj-h1">지난 공고</span>
+            <span className="block md:hidden tj-h3">지난 공고</span>
+            <span className="hidden md:block tj-h1">지난 공고</span>
           </div>
         )}
       </div>
@@ -88,8 +88,8 @@ export function PostCard({
               ${isInactive ? "text-gray-30" : "text-gray-black"}
             `}
           >
-            <span className="flex md:hidden tj-body1-bold">{title}</span>
-            <span className="hidden md:flex tj-h3">{title}</span>
+            <span className="block md:hidden tj-body1-bold">{title}</span>
+            <span className="hidden md:block tj-h3">{title}</span>
 
           </h3>
           <p
@@ -120,8 +120,8 @@ export function PostCard({
           >
             <PostPath
               className={`w-4 h-4 md:w-5 md:h-5 ${isInactive ? "text-gray-20" : "text-red-30"}`} />
-            <span className="hidden md:flex tj-body2">{locationText}</span>
-            <span className="flex md:hidden tj-caption">{locationText}</span>
+            <span className="hidden md:inline tj-body2">{locationText}</span>
+            <span className="inline md:hidden tj-caption">{locationText}</span>
           </p>
         </div>
 
@@ -133,8 +133,8 @@ export function PostCard({
               ${isInactive ? "text-gray-30" : "text-gray-black"}
             `}
           >
-            <span className="hidden md:flex tj-h2">{wage.toLocaleString()}원</span>
-            <span className="flex md:hidden tj-h4">{wage.toLocaleString()}원</span>
+            <span className="hidden md:block tj-h2">{wage.toLocaleString()}원</span>
+            <span className="block md:hidden tj-h4">{wage.toLocaleString()}원</span>
           </p>
 
           {wageBadgeText && (

--- a/src/components/post/postCard.tsx
+++ b/src/components/post/postCard.tsx
@@ -6,11 +6,9 @@ import PostPath from "./icon/PostPath";
 import PostClock from "./icon/PostClock";
 
 type PostStatus = "active" | "inactive";
-type PostSize = "large" | "small";
 
 export type PostCardProps = {
   status?: PostStatus;          // 공고 상태 (기본값: active)
-  size?: PostSize;              // 카드 크기 (기본값: large)
   title: string;                // 공고 제목
   scheduleText: string;         // 날짜/시간 텍스트
   locationText: string;         // 위치 텍스트
@@ -18,37 +16,11 @@ export type PostCardProps = {
   wageBadgeText?: string;       // 뱃지 텍스트 (예: "기존 시급보다 100%")
   thumbnailUrl: string;         // 상단 썸네일 이미지 URL
   onClick?: () => void;         // 카드 클릭 핸들러
+  className?: string;           // 페이지에서 tailwind 속성 추가
 };
-
-/**
- * 큰 카드/작은 카드 스타일
- */
-const SIZE_STYLE = {
-  large: {
-    card: "w-[312px] h-[348px] p-4 gap-5",
-    imageWrapper: "w-[280px] h-[160px]",
-    title: "tj-h3",
-    meta: "tj-body2",
-    wage: "tj-h2",
-    wageIncrease: "tj-body2-bold",
-    iconSize: 20,
-    inactiveLabel: "tj-h1",
-  },
-  small: {
-    card: "w-[171px] min-h-[260px] p-3 gap-3",
-    imageWrapper: "w-[147px] h-[84px]",
-    title: "tj-body1-bold",
-    meta: "tj-caption",
-    wage: "tj-h4",
-    wageIncrease: "tj-caption",
-    iconSize: 16,
-    inactiveLabel: "tj-h3",
-  },
-} as const;
 
 export function PostCard({
   status = "active",
-  size = "large",
   title,
   scheduleText,
   locationText,
@@ -56,131 +28,33 @@ export function PostCard({
   wageBadgeText,
   thumbnailUrl,
   onClick,
+  className,
 }: PostCardProps) {
   const isInactive = status === "inactive";
-  const styles = SIZE_STYLE[size];
 
-  // 작은 카드 날짜/시간 분리
-  const renderScheduleText = () => {
-    if (size === "small") {
-      const [datePart, ...rest] = scheduleText.split(" ");
-      const timePart = rest.join(" ");
-      return (
-        <span className="flex flex-col">
-          <span>{datePart}</span>
-          <span>{timePart}</span>
-        </span>
-      );
-    }
-  }
-  /** 날짜/위치 렌더링 */
-  const renderMeta = () => (
-    <>
-      {/* 날짜/시간 줄 */}
-      <p
-        className={[
-          "flex gap-1.5",
-          styles.meta,
-          isInactive ? "text-gray-30" : "text-gray-50",
-        ].join(" ")}
-      >
-        <PostClock
-          width={styles.iconSize}
-          height={styles.iconSize}
-          className={isInactive ? "text-gray-20" : "text-red-30"} />
-        {size === "small" ? renderScheduleText() : scheduleText}
-      </p>
-
-      {/* 위치 줄 */}
-      <p
-        className={[
-          "flex gap-1.5",
-          styles.meta,
-          isInactive ? "text-gray-30" : "text-gray-50",
-        ].join(" ")}
-      >
-        <PostPath
-          width={styles.iconSize}
-          height={styles.iconSize}
-          className={isInactive ? "text-gray-20" : "text-red-30"} />
-        <span>{locationText}</span>
-      </p>
-    </>
-  );
-
-  /** 큰 카드 전용 문구 뱃지*/
-  const renderLargeBadge = () => {
-    if (!wageBadgeText) return null;
-
-    const baseColor = isInactive ? "bg-gray-20 text-white" : "bg-red-40 text-white";
-
-    return (
-      <div
-        className={[
-          "flex items-center justify-center rounded-[20px] h-9 p-3",
-          baseColor,
-          styles.wageIncrease,
-        ].join(" ")}
-      >
-        <span>{wageBadgeText}</span>
-        <PostArrow
-          width={styles.iconSize}
-          height={styles.iconSize}
-          className="text-white" />
-      </div>
-    );
-  };
-
-  /** 작은 카드 전용 가격 아래 문구 */
-  const renderSmallBadge = () => {
-    if (!wageBadgeText) return null;
-
-    const baseColor = isInactive ? "text-gray-20" : "text-red-40";
-
-    return (
-      <div>
-        <div
-          className={[
-            baseColor,
-          ].join(" ")}
-        >
-          <span className="flex tj-caption text-center gap-0.5">
-            {wageBadgeText}
-            <PostArrow
-              width={styles.iconSize}
-              height={styles.iconSize}
-              className={isInactive ? "text-gray-20" : "text-red-40"} />
-          </span>
-        </div>
-      </div>
-    );
-  };
-
-  /** 사이즈별로 다른 뱃지 렌더링 */
-  const renderBadge = () => {
-    if (!wageBadgeText) return null;
-    if (size === "large") return renderLargeBadge();
-    return renderSmallBadge();
-  };
+  // 작은 카드(모바일에서 사용) 날짜/시간 분리
+  const [datePart, ...rest] = scheduleText.split(" ");
+  const timePart = rest.join(" ");
 
   return (
     <article
       onClick={onClick}
-      className={[
-        "relative flex flex-col rounded-xl",
-        "border border-gray-20 bg-white",
-        styles.card,
-        "cursor-pointer",
-      ]
-        .filter(Boolean)
-        .join(" ")}
+      className={`
+        relative flex flex-col rounded-xl
+        border border-gray-20 bg-white
+        w-[171px] min-h-[260px] p-3 gap-3
+        md:w-[312px] md:h-[348px] md:p-4 md:gap-5
+        cursor-pointer
+        ${className ?? ""}
+      `}
     >
       {/* =================== 썸네일 영역 =================== */}
       <div
-        className={[
-          "relative w-full overflow-hidden rounded-xl",
-          styles.imageWrapper,
-        ].join(" ")}
+        className="
+          relative overflow-hidden rounded-xl
+          w-[147px] h-[84px]
+          md:w-[280px] md:h-40
+          "
       >
         <Image
           src={thumbnailUrl}
@@ -192,10 +66,7 @@ export function PostCard({
         {/* 비활성(지난 공고) 오버레이 */}
         {isInactive && (
           <div className="absolute inset-0 flex items-center justify-center bg-black/70">
-            <span className={[
-              styles.inactiveLabel,
-              "text-gray-30",
-              ].join(" ")}>
+            <span className="text-gray-30 tj-h3 md:tj-h1">
               지난 공고
             </span>
           </div>
@@ -208,33 +79,87 @@ export function PostCard({
         <div className="flex flex-col gap-2">
           {/* 제목 */}
           <h3
-            className={[
-              styles.title,
-              isInactive ? "text-gray-30" : "text-gray-black",
-            ].join(" ")}
+            className={`
+              ${isInactive ? "text-gray-30" : "text-gray-black"}
+              tj-body1-bold md:tj-h3
+            `}
           >
             {title}
           </h3>
-          {renderMeta()}
+          <p
+            className={`
+              flex gap-1.5
+              ${isInactive ? "text-gray-30" : "text-gray-50"}
+              tj-caption md:tj-body2
+            `}
+          >
+            <PostClock
+              className={`w-4 h-4 md:w-5 md:h-5 ${isInactive ? "text-gray-20" : "text-red-30"}`} />
+
+            {/* 모바일 날짜/시간 두 줄로 표시 */}
+            <span className="flex flex-col md:hidden">
+              <span>{datePart}</span>
+              <span>{timePart}</span>
+            </span>
+
+            {/* md(태블릿) 이상 날짜/시간 한 줄로 표시 */}
+            <span className="hidden md:inline">{scheduleText}</span>
+          </p>
+
+          {/* 위치 줄 */}
+          <p
+            className={`
+              flex gap-1.5
+              tj-caption md:tj-body2
+              ${isInactive ? "text-gray-30" : "text-gray-50"}
+            `}
+          >
+            <PostPath
+              className={`w-4 h-4 md:w-5 md:h-5 ${isInactive ? "text-gray-20" : "text-red-30"}`} />
+            <span>{locationText}</span>
+          </p>
         </div>
 
         {/* =================== 시급 텍스트 =================== */}
-        <div className={["flex items-end", size === "large" ? "justify-between" : "flex-wrap"].join(" ")}>
+        <div className={`flex items-end flex-wrap md:justify-between`}>
           <p
-            className={[
-              styles.wage,
-              isInactive ? "text-gray-30" : "text-gray-black",
-            ].join(" ")}
+            className={`
+              tj-h4 md:tj-h2
+              w-full md:w-auto
+              ${isInactive ? "text-gray-30" : "text-gray-black"}
+            `}
           >
             {wage.toLocaleString()}원
           </p>
-          {/* large 에서는 같은 줄에 렌더링, small 에서는 아래에 렌더링 */}
-          {renderBadge()}
+
+          {wageBadgeText && (
+            <>
+              {/* md(태블릿 이상) 뱃지 */}
+              <div
+                className={`
+                  hidden md:flex items-center justify-center rounded-[20px] h-9 p-3
+                  ${isInactive ? "bg-gray-20 text-white" : "bg-red-40 text-white"}
+                  tj-caption md:tj-body2-bold
+                `}
+              >
+                <span>{wageBadgeText}</span>
+                <PostArrow
+                  className="w-5 h-5 text-white" />
+              </div>
+
+              {/* 모바일 가격 아래 문구 */}
+              <div className="flex md:hidden">
+                <span className={`flex tj-caption text-center gap-0.5 ${isInactive ? "text-gray-20" : "text-red-40"}`}>
+                  {wageBadgeText}
+                  <PostArrow
+                    className={`w-4 h-4 ${isInactive ? "text-gray-20" : "text-red-40"}`} />
+                </span>
+              </div>
+            </>
+          )}
+          
         </div>
-            
       </div>
-
-
     </article>
   );
 }

--- a/src/components/post/postCard.tsx
+++ b/src/components/post/postCard.tsx
@@ -18,6 +18,7 @@ export type PostCardProps = {
   thumbnailUrl: string;         // 상단 썸네일 이미지 URL
   onClick?: () => void;         // 카드 클릭 핸들러
   className?: string;           // 페이지에서 tailwind 속성 추가
+  thumbnailClassName?: string;
 };
 
 export function PostCard({
@@ -30,6 +31,7 @@ export function PostCard({
   thumbnailUrl,
   onClick,
   className,
+  thumbnailClassName,
 }: PostCardProps) {
   const isInactive = status === "inactive";
 
@@ -43,21 +45,22 @@ export function PostCard({
     <article
       onClick={onClick}
       className={`
-        relative flex flex-col rounded-xl
+        relative flex flex-col rounded-xl 
         border border-gray-20 bg-white
-        w-[171px] min-h-[260px] p-3 gap-3
-        md:w-[312px] md:h-[348px] md:p-4 md:gap-5
+        w-full p-3 gap-3
+        md:p-4 md:gap-5
         cursor-pointer
         ${className ?? ""}
       `}
     >
       {/* =================== 썸네일 영역 =================== */}
       <div
-        className="
+        className={`
           relative overflow-hidden rounded-xl
-          w-[147px] h-[84px]
+          w-full h-[84px]
           md:w-[280px] md:h-40
-          "
+          ${thumbnailClassName ?? ""}
+        `}
       >
         <Image
           src={thumbnailUrl}

--- a/src/components/post/postCard.tsx
+++ b/src/components/post/postCard.tsx
@@ -65,10 +65,9 @@ export function PostCard({
 
         {/* 비활성(지난 공고) 오버레이 */}
         {isInactive && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/70">
-            <span className="text-gray-30 tj-h3 md:tj-h1">
-              지난 공고
-            </span>
+          <div className="absolute inset-0 flex items-center justify-center bg-black/70 text-gray-30">
+            <span className="flex md:hidden tj-h3">지난 공고</span>
+            <span className="hidden md:flex tj-h1">지난 공고</span>
           </div>
         )}
       </div>
@@ -81,42 +80,42 @@ export function PostCard({
           <h3
             className={`
               ${isInactive ? "text-gray-30" : "text-gray-black"}
-              tj-body1-bold md:tj-h3
             `}
           >
-            {title}
+            <span className="flex md:hidden tj-body1-bold">{title}</span>
+            <span className="hidden md:flex tj-h3">{title}</span>
+
           </h3>
           <p
             className={`
               flex gap-1.5
               ${isInactive ? "text-gray-30" : "text-gray-50"}
-              tj-caption md:tj-body2
             `}
           >
             <PostClock
               className={`w-4 h-4 md:w-5 md:h-5 ${isInactive ? "text-gray-20" : "text-red-30"}`} />
 
             {/* 모바일 날짜/시간 두 줄로 표시 */}
-            <span className="flex flex-col md:hidden">
+            <span className="flex flex-col md:hidden tj-caption">
               <span>{datePart}</span>
               <span>{timePart}</span>
             </span>
 
             {/* md(태블릿) 이상 날짜/시간 한 줄로 표시 */}
-            <span className="hidden md:inline">{scheduleText}</span>
+            <span className="hidden md:inline tj-body2">{scheduleText}</span>
           </p>
 
           {/* 위치 줄 */}
           <p
             className={`
               flex gap-1.5
-              tj-caption md:tj-body2
               ${isInactive ? "text-gray-30" : "text-gray-50"}
             `}
           >
             <PostPath
               className={`w-4 h-4 md:w-5 md:h-5 ${isInactive ? "text-gray-20" : "text-red-30"}`} />
-            <span>{locationText}</span>
+            <span className="hidden md:flex tj-body2">{locationText}</span>
+            <span className="flex md:hidden tj-caption">{locationText}</span>
           </p>
         </div>
 
@@ -124,12 +123,12 @@ export function PostCard({
         <div className={`flex items-end flex-wrap md:justify-between`}>
           <p
             className={`
-              tj-h4 md:tj-h2
               w-full md:w-auto
               ${isInactive ? "text-gray-30" : "text-gray-black"}
             `}
           >
-            {wage.toLocaleString()}원
+            <span className="hidden md:flex tj-h2">{wage.toLocaleString()}원</span>
+            <span className="flex md:hidden tj-h4">{wage.toLocaleString()}원</span>
           </p>
 
           {wageBadgeText && (
@@ -139,25 +138,23 @@ export function PostCard({
                 className={`
                   hidden md:flex items-center justify-center rounded-[20px] h-9 p-3
                   ${isInactive ? "bg-gray-20 text-white" : "bg-red-40 text-white"}
-                  tj-caption md:tj-body2-bold
                 `}
               >
-                <span>{wageBadgeText}</span>
+                <span className="tj-body2-bold">{wageBadgeText}</span>
                 <PostArrow
                   className="w-5 h-5 text-white" />
               </div>
 
               {/* 모바일 가격 아래 문구 */}
               <div className="flex md:hidden">
-                <span className={`flex tj-caption text-center gap-0.5 ${isInactive ? "text-gray-20" : "text-red-40"}`}>
-                  {wageBadgeText}
+                <div className={`flex text-center gap-0.5 ${isInactive ? "text-gray-20" : "text-red-40"}`}>
+                  <span className="tj-caption">{wageBadgeText}</span>
                   <PostArrow
                     className={`w-4 h-4 ${isInactive ? "text-gray-20" : "text-red-40"}`} />
-                </span>
+                </div>
               </div>
             </>
-          )}
-          
+          )}    
         </div>
       </div>
     </article>

--- a/src/components/post/postCard.tsx
+++ b/src/components/post/postCard.tsx
@@ -152,12 +152,10 @@ export function PostCard({
               </div>
 
               {/* 모바일 가격 아래 문구 */}
-              <div className="flex md:hidden">
-                <div className={`flex text-center gap-0.5 ${isInactive ? "text-gray-20" : "text-red-40"}`}>
-                  <span className="tj-caption">{wageBadgeText}</span>
-                  <PostArrow
-                    className={`w-4 h-4 ${isInactive ? "text-gray-20" : "text-red-40"}`} />
-                </div>
+              <div className={`flex md:hidden text-center gap-0.5 ${isInactive ? "text-gray-20" : "text-red-40"}`}>
+                <span className="tj-caption">{wageBadgeText}</span>
+                <PostArrow
+                  className={`w-4 h-4 ${isInactive ? "text-gray-20" : "text-red-40"}`} />
               </div>
             </>
           )}

--- a/src/components/post/postCard.tsx
+++ b/src/components/post/postCard.tsx
@@ -46,21 +46,15 @@ export function PostCard({
   return (
     <article
       onClick={onClick}
-      className={`
-        relative flex flex-col rounded-xl 
-        border border-gray-20 bg-white
-        w-full p-3 gap-3
-        md:p-4 md:gap-5
-        cursor-pointer
+      className={`relative flex flex-col rounded-xl border border-gray-20 bg-white cursor-pointer
+        w-full p-3 gap-3 md:p-4 md:gap-5
         ${className ?? ""}
       `}
     >
       {/* =================== 썸네일 영역 =================== */}
       <div
-        className={`
-          relative overflow-hidden rounded-xl
-          w-full h-[84px]
-          md:w-[280px] md:h-40
+        className={`relative overflow-hidden rounded-xl
+          w-full h-[84px] md:w-[280px] md:h-40
           ${thumbnailClassName ?? ""}
         `}
       >
@@ -143,8 +137,7 @@ export function PostCard({
             <>
               {/* md(태블릿 이상) 뱃지 */}
               <div
-                className={`
-                  hidden md:flex items-center justify-center rounded-[20px] h-9 p-3
+                className={`hidden md:flex items-center justify-center rounded-[20px] h-9 p-3
                   ${isInactive ? "bg-gray-20 text-white" : "bg-red-40 text-white"}
                 `}
               >

--- a/src/components/post/postCard.tsx
+++ b/src/components/post/postCard.tsx
@@ -19,6 +19,7 @@ export type PostCardProps = {
   onClick?: () => void;         // 카드 클릭 핸들러
   className?: string;           // 페이지에서 tailwind 속성 추가
   thumbnailClassName?: string;
+  inactiveLabelText?: string;   // 비활성화 썸네일 문구 (지난 공고/마감 완료)
 };
 
 export function PostCard({
@@ -32,6 +33,7 @@ export function PostCard({
   onClick,
   className,
   thumbnailClassName,
+  inactiveLabelText = "지난 공고",
 }: PostCardProps) {
   const isInactive = status === "inactive";
 
@@ -72,8 +74,8 @@ export function PostCard({
         {/* 비활성(지난 공고) 오버레이 */}
         {isInactive && (
           <div className="absolute inset-0 flex items-center justify-center bg-black/70 text-gray-30">
-            <span className="block md:hidden tj-h3">지난 공고</span>
-            <span className="hidden md:block tj-h1">지난 공고</span>
+            <span className="block md:hidden tj-h3">{inactiveLabelText}</span>
+            <span className="hidden md:block tj-h1">{inactiveLabelText}</span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## 🔗 관련 이슈
#66 

## ✨ 변경 사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 변경
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 기타

## 📌 PR 요약 (선택)
큰카드/작은카드 분리 형식에서 md 분기 반응형으로 수정하였습니다
tailwind 768px 반응형이지만 피그마 태블릿에 맞게 md를 744px 분기로 변경하면 될 것 같습니다
페이지에 사용되는 포스트 카드들의 경우 음식점 사진만 크기가 고정되어 있고 포스트 카드는 음식점 사진 크기에 맞게 패딩으로 크기가 조정됩니다
필요에 따라 tailwind 속성을 지정할 수 있도록
포스트 카드 속성은 className로 넘겨받고, 음식점 사진(썸네일)은 thumbnailClassName로 넘겨받도록 하였습니다
날짜/시간 분리 로직을 useMemo를 사용하는 것으로 수정하였습니다
svgr을 사용하려고 했으나 next16은 터보팩을 사용하고, svgr은 웹팩이 권장되어 강제로 웹팩을 사용하도록 설정해야되는데 이건 아닌것 같아서 svg 컴포넌트 형식을 유지하였습니다
문서 구조 통일화 작업 필요시 아이콘 svg 이미지 7개를 사용하는 쪽으로 수정하겠습니다

## 📸 스크린샷 (선택)

Closes #66
