### PR TITLE
[#158] [REFACTOR] 포스트카드 시급 증가량에 따른 색상 분기

### DIFF
--- a/src/components/post/postCard.tsx
+++ b/src/components/post/postCard.tsx
@@ -9,18 +9,18 @@ import PostClock from './icon/PostClock';
 type PostStatus = 'active' | 'inactive';
 
 export type PostCardProps = {
-  id?: string | number; // 카드 id
-  status?: PostStatus; // 공고 상태 (기본값: active)
-  title: string; // 공고 제목
-  scheduleText: string; // 날짜/시간 텍스트
-  locationText: string; // 위치 텍스트
-  wage: number; // 시급
-  wageBadgeText?: string; // 뱃지 텍스트 (예: "기존 시급보다 100%")
-  thumbnailUrl?: string; // 상단 썸네일 이미지 URL (없으면 플레이스홀더)
-  onClick?: () => void; // 카드 클릭 핸들러
-  className?: string; // 페이지에서 tailwind 속성 추가
+  id?: string | number;          // 카드 id
+  status?: PostStatus;           // 공고 상태 (기본값: active)
+  title: string;                 // 공고 제목
+  scheduleText: string;          // 날짜/시간 텍스트
+  locationText: string;          // 위치 텍스트
+  wage: number;                  // 시급
+  wageBadgeText?: string;        // 뱃지 텍스트 (예: "시급 30% ↑", 없으면 빈 슬롯)
+  thumbnailUrl?: string;         // 상단 썸네일 이미지 URL (없으면 플레이스홀더)
+  onClick?: () => void;          // 카드 클릭 핸들러
+  className?: string;            // 페이지에서 tailwind 속성 추가
   thumbnailClassName?: string;
-  inactiveLabelText?: string; // 비활성화 썸네일 문구 (지난 공고/마감 완료)
+  inactiveLabelText?: string;    // 비활성화 썸네일 문구 (지난 공고/마감 완료)
 };
 
 /* ================================
@@ -41,8 +41,8 @@ function getDesktopBadgeClass(isInactive: boolean, percent: number): string {
   if (percent >= 30) return 'bg-red-30 text-white';
   if (percent > 0) return 'bg-red-20 text-white';
 
-  // 0%거나 %가 없을 때 기본값
-  return 'bg-red-20 text-white';
+  // 0%거나 %가 없을 때는 색 없음 (빈 슬롯)
+  return '';
 }
 
 function getMobileBadgeColorClass(isInactive: boolean, percent: number): string {
@@ -52,6 +52,7 @@ function getMobileBadgeColorClass(isInactive: boolean, percent: number): string 
   if (percent >= 30) return 'text-red-30';
   if (percent > 0) return 'text-red-20';
 
+  // 0%는 색 없음
   return '';
 }
 
@@ -87,6 +88,9 @@ export const PostCard = memo(function PostCard({
   const increasePercent = getIncreasePercent(wageBadgeText);
   const desktopBadgeClass = getDesktopBadgeClass(isInactive, increasePercent);
   const mobileBadgeColorClass = getMobileBadgeColorClass(isInactive, increasePercent);
+
+  // 실제로 텍스트/아이콘이 보이는 뱃지인지 여부 (0%면 안 보이게)
+  const showBadge = !!wageBadgeText && increasePercent > 0;
 
   return (
     <article
@@ -175,8 +179,8 @@ export const PostCard = memo(function PostCard({
           </p>
         </div>
 
-        {/* =================== 시급 텍스트 =================== */}
-        <div className={`flex items-end flex-wrap md:justify-between`}>
+        {/* =================== 시급 텍스트 + 뱃지 슬롯 =================== */}
+        <div className="flex items-end flex-wrap md:justify-between">
           <p
             className={`
               w-full md:w-auto
@@ -187,29 +191,38 @@ export const PostCard = memo(function PostCard({
             <span className="block md:hidden tj-h4">{wage.toLocaleString()}원</span>
           </p>
 
-          {wageBadgeText && increasePercent > 0 && (
-            <>
-              <div
-                className={`
-                  hidden md:flex items-center justify-center rounded-[20px] h-9 p-3
-                  ${desktopBadgeClass}
-                `}
-              >
+          {/* md 이상: 항상 슬롯은 있고, showBadge일 때만 내용 보임 */}
+          <div
+            className={`
+              hidden md:flex items-center justify-center rounded-[20px] h-9 p-3
+              ${showBadge ? desktopBadgeClass : ''}
+            `}
+          >
+            {showBadge ? (
+              <>
                 <span className="tj-body2-bold">{wageBadgeText}</span>
                 <PostArrow className="w-5 h-5 text-white" />
-              </div>
+              </>
+            ) : (
+              // 빈 슬롯: 높이만 맞추기 위해 투명 텍스트
+              <span className="tj-body2-bold opacity-0">placeholder</span>
+            )}
+          </div>
 
-              <div
-                className={`
-                  flex md:hidden text-center gap-0.5
-                  ${mobileBadgeColorClass}
-                `}
-              >
-                <span className="tj-caption">{wageBadgeText}</span>
+          {/* 모바일: 역시 슬롯은 항상 있고, showBadge일 때만 색/내용 표시 */}
+          <div className="flex md:hidden text-center gap-0.5">
+            {showBadge ? (
+              <>
+                <span className={`tj-caption ${mobileBadgeColorClass}`}>{wageBadgeText}</span>
                 <PostArrow className={`w-4 h-4 ${mobileBadgeColorClass}`} />
-              </div>
-            </>
-          )}
+              </>
+            ) : (
+              <>
+                <span className="tj-caption opacity-0">&nbsp;</span>
+                <PostArrow className="w-4 h-4 opacity-0" />
+              </>
+            )}
+          </div>
         </div>
       </div>
     </article>

--- a/src/components/post/postCard.tsx
+++ b/src/components/post/postCard.tsx
@@ -52,7 +52,7 @@ function getMobileBadgeColorClass(isInactive: boolean, percent: number): string 
   if (percent >= 30) return 'text-red-30';
   if (percent > 0) return 'text-red-20';
 
-  return 'text-red-20';
+  return '';
 }
 
 export const PostCard = memo(function PostCard({
@@ -187,7 +187,7 @@ export const PostCard = memo(function PostCard({
             <span className="block md:hidden tj-h4">{wage.toLocaleString()}원</span>
           </p>
 
-          {wageBadgeText && (
+          {wageBadgeText && increasePercent > 0 && (
             <>
               <div
                 className={`

--- a/src/components/post/postCard.tsx
+++ b/src/components/post/postCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import React, { memo, useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import PostArrow from './icon/PostArrow';
 import PostPath from './icon/PostPath';
 import PostClock from './icon/PostClock';
@@ -22,6 +22,38 @@ export type PostCardProps = {
   thumbnailClassName?: string;
   inactiveLabelText?: string; // 비활성화 썸네일 문구 (지난 공고/마감 완료)
 };
+
+/* ================================
+ * 시급 증가율(%)에 따른 색상 계산 헬퍼들
+ * - 증가율에 따라 red-20 / red-30 / red-40 분기
+ * ================================ */
+
+function getIncreasePercent(text?: string): number {
+  if (!text) return 0;
+  const match = text.match(/(\d+)\s*%/); // "30%" 또는 "30 %" 같은 경우
+  return match ? Number(match[1]) : 0;
+}
+
+function getDesktopBadgeClass(isInactive: boolean, percent: number): string {
+  if (isInactive) return 'bg-gray-20 text-white';
+
+  if (percent >= 50) return 'bg-red-40 text-white';
+  if (percent >= 30) return 'bg-red-30 text-white';
+  if (percent > 0) return 'bg-red-20 text-white';
+
+  // 0%거나 %가 없을 때 기본값
+  return 'bg-red-20 text-white';
+}
+
+function getMobileBadgeColorClass(isInactive: boolean, percent: number): string {
+  if (isInactive) return 'text-gray-20';
+
+  if (percent >= 50) return 'text-red-40';
+  if (percent >= 30) return 'text-red-30';
+  if (percent > 0) return 'text-red-20';
+
+  return 'text-red-20';
+}
 
 export const PostCard = memo(function PostCard({
   id,
@@ -50,6 +82,11 @@ export const PostCard = memo(function PostCard({
     const [date, ...rest] = scheduleText.split(' ');
     return [date, rest.join(' ')];
   }, [scheduleText]);
+
+  // 시급 증가율(%) 파싱 및 색상 클래스 계산
+  const increasePercent = getIncreasePercent(wageBadgeText);
+  const desktopBadgeClass = getDesktopBadgeClass(isInactive, increasePercent);
+  const mobileBadgeColorClass = getMobileBadgeColorClass(isInactive, increasePercent);
 
   return (
     <article
@@ -152,22 +189,24 @@ export const PostCard = memo(function PostCard({
 
           {wageBadgeText && (
             <>
-              {/* md(태블릿 이상) 뱃지 */}
               <div
-                className={`hidden md:flex items-center justify-center rounded-[20px] h-9 p-3
-                  ${isInactive ? 'bg-gray-20 text-white' : 'bg-red-40 text-white'}
+                className={`
+                  hidden md:flex items-center justify-center rounded-[20px] h-9 p-3
+                  ${desktopBadgeClass}
                 `}
               >
                 <span className="tj-body2-bold">{wageBadgeText}</span>
                 <PostArrow className="w-5 h-5 text-white" />
               </div>
 
-              {/* 모바일 가격 아래 문구 */}
               <div
-                className={`flex md:hidden text-center gap-0.5 ${isInactive ? 'text-gray-20' : 'text-red-40'}`}
+                className={`
+                  flex md:hidden text-center gap-0.5
+                  ${mobileBadgeColorClass}
+                `}
               >
                 <span className="tj-caption">{wageBadgeText}</span>
-                <PostArrow className={`w-4 h-4 ${isInactive ? 'text-gray-20' : 'text-red-40'}`} />
+                <PostArrow className={`w-4 h-4 ${mobileBadgeColorClass}`} />
               </div>
             </>
           )}


### PR DESCRIPTION
## 🔗 관련 이슈
#158 

## ✨ 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI 변경
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 기타

## 📌 PR 요약 (선택)
시급 증가량과 반응형 분기에 따른 뱃지색/텍스트색 분기
투명 문자로 채우면서 높낮이 다른 문제 해결

## 📸 스크린샷 (선택)

<img width="937" height="755" alt="image" src="https://github.com/user-attachments/assets/b5c3ad6d-1378-4b93-91e5-e9c628e89b59" />
<img width="470" height="559" alt="image" src="https://github.com/user-attachments/assets/8913a2bc-8963-4eae-b298-1c399cb64fcc" />

Closes #158
